### PR TITLE
add name attribute to custom extensions

### DIFF
--- a/extension.go
+++ b/extension.go
@@ -5,6 +5,7 @@ import "encoding/xml"
 // Extension represent arbitrary XML provided by the platform to extend the
 // VAST response or by custom trackers.
 type Extension struct {
+	Name           string     `xml:"name,attr,omitempty"`
 	Type           string     `xml:"type,attr,omitempty"`
 	CustomTracking []Tracking `xml:"CustomTracking>Tracking,omitempty"`
 	Data           []byte     `xml:",innerxml"`
@@ -14,6 +15,7 @@ type Extension struct {
 type extension Extension
 
 type extensionNoCT struct {
+	Name string `xml:"name,attr,omitempty"`
 	Type string `xml:"type,attr,omitempty"`
 	Data []byte `xml:",innerxml"`
 }
@@ -26,9 +28,9 @@ func (e Extension) MarshalXML(enc *xml.Encoder, start xml.StartElement) error {
 	// if we have custom trackers, we should ignore the data, if not, then we
 	// should consider only the data.
 	if len(e.CustomTracking) > 0 {
-		e2 = extension{Type: e.Type, CustomTracking: e.CustomTracking}
+		e2 = extension{Name: e.Name, Type: e.Type, CustomTracking: e.CustomTracking}
 	} else {
-		e2 = extensionNoCT{Type: e.Type, Data: e.Data}
+		e2 = extensionNoCT{Name: e.Name, Type: e.Type, Data: e.Data}
 	}
 
 	return enc.EncodeElement(e2, start)
@@ -43,6 +45,7 @@ func (e *Extension) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error
 		return err
 	}
 	// copy the type and the customTracking
+	e.Name = e2.Name
 	e.Type = e2.Type
 	e.CustomTracking = e2.CustomTracking
 	// copy the data only of customTracking is empty

--- a/extension_test.go
+++ b/extension_test.go
@@ -8,12 +8,13 @@ import (
 )
 
 var (
-	extensionCustomTracking = []byte(`<Extension type="testCustomTracking"><CustomTracking><Tracking event="event.1"><![CDATA[http://event.1]]></Tracking><Tracking event="event.2"><![CDATA[http://event.2]]></Tracking></CustomTracking></Extension>`)
-	extensionData           = []byte(`<Extension type="testCustomTracking"><SkippableAdType>Generic</SkippableAdType></Extension>`)
+	extensionCustomTracking = []byte(`<Extension name="a.custom.extension.tracking" type="testCustomTracking"><CustomTracking><Tracking event="event.1"><![CDATA[http://event.1]]></Tracking><Tracking event="event.2"><![CDATA[http://event.2]]></Tracking></CustomTracking></Extension>`)
+	extensionData           = []byte(`<Extension name="a custom extension" type="testCustomTracking"><SkippableAdType>Generic</SkippableAdType></Extension>`)
 )
 
 func TestExtensionCustomTrackingMarshal(t *testing.T) {
 	e := Extension{
+		Name: "a.custom.extension.tracking",
 		Type: "testCustomTracking",
 		CustomTracking: []Tracking{
 			{
@@ -41,6 +42,7 @@ func TestExtensionCustomTracking(t *testing.T) {
 	assert.NoError(t, xml.Unmarshal(extensionCustomTracking, &e))
 
 	// assert the resulting extension
+	assert.Equal(t, "a.custom.extension.tracking", e.Name)
 	assert.Equal(t, "testCustomTracking", e.Type)
 	assert.Empty(t, string(e.Data))
 	if assert.Len(t, e.CustomTracking, 2) {
@@ -66,6 +68,7 @@ func TestExtensionGeneric(t *testing.T) {
 	assert.NoError(t, xml.Unmarshal(extensionData, &e))
 
 	// assert the resulting extension
+	assert.Equal(t, "a custom extension", e.Name)
 	assert.Equal(t, "testCustomTracking", e.Type)
 	assert.Equal(t, "<SkippableAdType>Generic</SkippableAdType>", string(e.Data))
 	assert.Empty(t, e.CustomTracking)


### PR DESCRIPTION
Adds the `name` attribute to extensions to easily identify extensions when provided