### PR TITLE
add pricing data to wrapper

### DIFF
--- a/testdata/vast_wrapper_linear_1.xml
+++ b/testdata/vast_wrapper_linear_1.xml
@@ -39,6 +39,7 @@
 			</NonLinearAds>
 		</Creative>
 	</Creatives>
+	<Pricing model="cpm" currency="usd">1.471509</Pricing>
   </Wrapper>
   </Ad>
 </VAST>

--- a/testdata/vast_wrapper_nonlinear_1.xml
+++ b/testdata/vast_wrapper_nonlinear_1.xml
@@ -25,6 +25,7 @@
 			</NonLinearAds>
 		</Creative>
 	</Creatives>
+	<Pricing model="cpm" currency="usd">1.471509</Pricing>
   </Wrapper>
   </Ad>
 </VAST>

--- a/vast.go
+++ b/vast.go
@@ -50,7 +50,7 @@ type InLine struct {
 	// One or more URIs that directs the video player to a tracking resource file that the
 	// video player should request when the first frame of the ad is displayed
 	Impressions []Impression `xml:"Impression"`
-	Categories []Category `xml:"Category"`
+	Categories  []Category   `xml:"Category"`
 	// The container for one or more <Creative> elements
 	Creatives []Creative `xml:"Creatives>Creative"`
 	// A string value that provides a longer description of the ad.
@@ -84,7 +84,7 @@ type InLine struct {
 
 type Category struct {
 	Authority string `xml:"authority,attr"`
-	Value string `xml:",cdata"`
+	Value     string `xml:",cdata"`
 }
 
 // Impression is a URI that directs the video player to a tracking resource file that
@@ -134,6 +134,10 @@ type Wrapper struct {
 	// XML elements from VAST elements. The following example includes a custom
 	// xml element within the Extensions element.
 	Extensions []Extension `xml:"Extensions>Extension,omitempty"`
+	// Pricing provides a value that represents a price that can be used by real-time
+	// bidding (RTB) systems. VAST is not designed to handle RTB since other methods
+	// exist,  but this element is offered for custom solutions if needed.
+	Pricing *Pricing `xml:",omitempty"`
 
 	FallbackOnNoAd           *bool `xml:"fallbackOnNoAd,attr,omitempty"`
 	AllowMultipleAds         *bool `xml:"allowMultipleAds,attr,omitempty"`

--- a/vast_test.go
+++ b/vast_test.go
@@ -390,6 +390,12 @@ func TestWrapperLinear(t *testing.T) {
 					}
 				}
 			}
+
+			if assert.NotNil(t, wrapper.Pricing) {
+				assert.Equal(t, "cpm", wrapper.Pricing.Model)
+				assert.Equal(t, "usd", wrapper.Pricing.Currency)
+				assert.Equal(t, "1.471509", wrapper.Pricing.Value)
+			}
 		}
 	}
 }
@@ -434,6 +440,12 @@ func TestWrapperNonLinear(t *testing.T) {
 						assert.Equal(t, "http://myTrackingURL/wrapper/nonlinear/creativeView/creativeView", crea2.NonLinearAds.TrackingEvents[0].URI)
 					}
 				}
+			}
+
+			if assert.NotNil(t, wrapper.Pricing) {
+				assert.Equal(t, "cpm", wrapper.Pricing.Model)
+				assert.Equal(t, "usd", wrapper.Pricing.Currency)
+				assert.Equal(t, "1.471509", wrapper.Pricing.Value)
 			}
 		}
 	}
@@ -649,9 +661,9 @@ func TestCategory(t *testing.T) {
 		ad := v.Ads[0]
 		assert.Equal(t, "20008", ad.ID)
 		if assert.NotNil(t, ad.InLine) {
-			if assert.NotNil(t,ad.InLine.Categories){
-				assert.Equal(t, "AD CONTENT description category",ad.InLine.Categories[0].Value)
-				assert.Equal(t, "http://www.iabtechlab.com/categoryauthority",ad.InLine.Categories[0].Authority)
+			if assert.NotNil(t, ad.InLine.Categories) {
+				assert.Equal(t, "AD CONTENT description category", ad.InLine.Categories[0].Value)
+				assert.Equal(t, "http://www.iabtechlab.com/categoryauthority", ad.InLine.Categories[0].Authority)
 			}
 		}
 	}


### PR DESCRIPTION
Pricing data can appear in wrapper. Adding into help catch pricing from partners who include pricing data in the `Wrapper`, but not the subsequent `InLine`